### PR TITLE
Adds support for cloning builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,7 @@ set -o pipefail
 unset AWS_ACCESS_KEY_ID
 unset AWS_SECRET_ACCESS_KEY
 unset GITHUB_TOKEN
+unset CALLBACK
 
 # Run build process based on configuration files
 

--- a/clone.sh
+++ b/clone.sh
@@ -5,8 +5,15 @@ set -e
 set -o pipefail
 
 # Download repository from GitHub
-git clone -b $BRANCH --single-branch \
-  https://${GITHUB_TOKEN}@github.com/${OWNER}/${REPOSITORY}.git .
+if [ -z "$SOURCE_OWNER" ] && [ -z "$SOURCE_REPO" ]; then
+  git clone -b $BRANCH --single-branch \
+    https://${GITHUB_TOKEN}@github.com/${SOURCE_OWNER}/${SOURCE_REPO}.git .
+  git remote add destination https://${GITHUB_TOKEN}@github.com/${OWNER}/${REPOSITORY}.git
+  git push destination $BRANCH
+else
+  git clone -b $BRANCH --single-branch \
+    https://${GITHUB_TOKEN}@github.com/${OWNER}/${REPOSITORY}.git .
+fi
 
 # Remove _site if it exists (otherwise we'll get a permission error)
 rm -rf _site


### PR DESCRIPTION
If env vars `SOURCE_OWNER` and `SOURCE_REPO` are set, clone the source repo and push it to the destination before building.