### PR TITLE
Add commit details to site object

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,6 +18,7 @@ unset CALLBACK
 if [ "$GENERATOR" = "jekyll" ]; then
 
   # Add Federalist configuration settings
+  git log -1 --pretty=format:'%ncommit: {%n "commit": "%H",%n "author": "%an <%ae>",%n "date": "%ad",%n "message": "%s"%n}' >> _config.yml
   echo -e "\nbaseurl: ${BASEURL-"''"}\nbranch: ${BRANCH}\n${CONFIG}" >> _config.yml
 
   if [[ -f Gemfile ]]; then


### PR DESCRIPTION
Adds commit details to the `site` object.

eg:

```json
commit: {
 "commit": "8ebcd8d344ac417288304ae7cba630fae3dbe1b6",
 "author": "Dave Cole <david.cole@gsa.gov>",
 "date": "Mon Jan 25 12:13:47 2016 -0500",
 "message": "Test message"
}
```