### PR TITLE
Whitelist ASCII characters for status update POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ Configure the build process with following environment variables:
 
 The AWS and GitHub token variables are unset in the Jekyll subprocess so Jekyll and its plugins do not have access to this information.
 
+### Development & making changes
+
+You'll need to have `docker` on your machine installed. If you just want to install the container image and run it, you can use `docker pull 18fgsa/federalist-docker-build`. `docker pull` behaves similarly to `git pull`. Run the container with `docker run 18fgsa/federalist-docker-build`.
+
+If you want to make changes, you should first clone the repo and then build the docker container locally.
+
+0. `git clone git@github.com:18F/federalist-docker-build.git && cd federalist-docker-build`
+0. `docker build -t federalist-docker-build .`
+0. `docker run federalist-docker-build`
+
+After you make any changes to the container, you should run the `docker build` command again before `docker run`.
+
+In either case you'll want to supply your docker container with environment variables. `docker run` accepts an `-e` flag to designate environment variables. You must precede each key/value pair with the flag. For example:
+`docker run -e OWNER=18f -e REPOSITORY=18f.gsa.gov federalist-docker-build` (if you used `docker pull` this container image is probably named `18fgsa/federalist-docker-build`).
 
 ### Public domain
 

--- a/main.sh
+++ b/main.sh
@@ -15,11 +15,9 @@ post () {
     output=""
   fi
 
-  output=`echo $output | tr -cd '\11\12\15\40-\176'`
-
   # POST to build finished endpoint
   curl -H "Content-Type: application/json" \
-    -d "{\"status\":\"$status\",\"message\":\"`echo $output`\"}" \
+    -d "{\"status\":\"$status\",\"message\":\"`echo -n $output | base64 --wrap=0`\"}" \
     $CALLBACK
 }
 

--- a/main.sh
+++ b/main.sh
@@ -15,6 +15,8 @@ post () {
     output=""
   fi
 
+  output=`echo $output | tr -cd '\11\12\15\40-\176'`
+
   # POST to build finished endpoint
   curl -H "Content-Type: application/json" \
     -d "{\"status\":\"$status\",\"message\":\"`echo $output`\"}" \


### PR DESCRIPTION
@yozlet had some issues adding a site to Federalist, and in the process of debugging it we discovered that characters used for color formatting output were not being handled properly by the [node app](/18f/federalist).

Here is an [example of such a request](https://www.runscope.com/public/7f8781d2-660e-412d-8493-a8b13760f650/fa7bab58-2300-48fc-8901-6a230f55793e). The server was returning a 400 instead of a 200.

This change is so that the POSTed output is piped through `tr` first. Here is an [example of a request](https://www.runscope.com/public/7f8781d2-660e-412d-8493-a8b13760f650/5df4eeb5-798e-405d-88b5-b5ef6dc53683) made utilizing `tr`.

Here is the command I tested with for ease of replication:

```
echo "Starting a test build"
docker run -e CALLBACK='<<your federalist server address>>/build/status/8385/prodBuildtoken' \
-e BASEURL='/' \
-e BRANCH=18f-pages \
-e REPOSITORY=wds-federalist \
-e OWNER=yozlet \
-e GENERATOR=jekyll \
-e  GITHUB_TOKEN=<<any github token that has read access to the repo should work>> \
federalist-docker-build
```

I also updated the documentation to include steps for local development.