### PR TITLE
Change the `mv` command to exclude the directory

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,6 +35,8 @@ elif [ "$GENERATOR" = "hugo" ]; then
 
 # Static files
 else
+  shopt -s extglob dotglob
   mkdir _site
-  mv * _site/
+  mv !(_site) _site
+  shopt -u dotglob
 fi


### PR DESCRIPTION
Currently, the build.sh command makes a `_site` directory, and
then proceeds to try to move everything in the current directory
into `_site`, *including the `_site` itself*.

This commit instead moves everything *except* `_site` into site.
The use of the `shopt` command is to find hidden files (because
strangely not including this causes bash to freak out a bit).

This could certainly be more elegant, but seems to work.