### PR TITLE
Fix static site build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,6 +35,8 @@ elif [ "$GENERATOR" = "hugo" ]; then
 
 # Static files
 else
+  shopt -s extglob dotglob
   mkdir _site
-  mv * _site/
+  mv !(_site) _site
+  shopt -u dotglob
 fi

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,7 @@
 # Stop script on errors
 set -e
 set -o pipefail
+shopt -s extglob dotglob
 
 # Remove sensitive environment variables
 unset AWS_ACCESS_KEY_ID
@@ -35,8 +36,6 @@ elif [ "$GENERATOR" = "hugo" ]; then
 
 # Static files
 else
-  shopt -s extglob dotglob
   mkdir _site
   mv !(_site) _site
-  shopt -u dotglob
 fi


### PR DESCRIPTION
This is based off of #11 and fixes some of the behavior of that branch. I am closing that issue in favor of this one. @vzvenyach's original PR comment:
> Currently, the build.sh command makes a _site directory, and then proceeds to try to move everything in the current directory into _site, including the _site itself.
>
> This commit instead moves everything except _site into site. The use of the `shopt` command is to find hidden files (because strangely not including this causes bash to freak out a bit).
>
> This could certainly be more elegant, but seems to work.

I adjusted the script so that the `shopt` option is used outside of an if/then/else block. In some my testing, `shopt` does not work inside of a block.

Huge h/t to @toolness for his help on figuring this one out 🎉 

Refs #8