### PR TITLE
Install python before isntalling AWS CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM 18fgsa/docker-ruby-ubuntu
 RUN gem install jekyll jekyll:3.0.1 jekyll:3.0.0 jekyll:2.5.3 jekyll:2.4.0 github-pages
 
 # Install the AWS CLI
-RUN curl https://bootstrap.pypa.io/get-pip.py | python \
+RUN apt-get install python3 \
+  && curl https://bootstrap.pypa.io/get-pip.py | python3 \
   && pip install awscli
 
 # Copy the script files


### PR DESCRIPTION
This commit installs python before installing the AWS CLI. This is in response to 18f/ruby-docker-ubuntu#3 which removes the trusty buildpack which included python.