### PR TITLE
Use python3 to build awscli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM 18fgsa/docker-ruby-ubuntu
 RUN gem install jekyll jekyll:3.0.1 jekyll:3.0.0 jekyll:2.5.3 jekyll:2.4.0 github-pages
 
 # Install the AWS CLI
-RUN curl https://bootstrap.pypa.io/get-pip.py | python \
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
   && pip install awscli
 
 # Copy the script files


### PR DESCRIPTION
This commit uses `python3` to install awscli since `python` is no longer installed in `18fgsa/docker-ruby-ubuntu`.