### PR TITLE
Change AWS region to GovCloud region

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -16,7 +16,7 @@ for i in `find . | grep -E "\.html$|\.css$|\.js$|\.json$|\.svg$"`; do
   fi
 done
 
-export AWS_DEFAULT_REGION=us-east-1
+export AWS_DEFAULT_REGION=us-gov-west-1
 
 # sync compressed files
 aws s3 sync . s3://${BUCKET}/${PREFIX}/ --no-follow-symlinks \


### PR DESCRIPTION
This commit changes the region that `publish.sh` publishes sites to from E/W to GovCloud. This was necessary because we are migrating our sites from S3 in E/W to S3 in GovCloud.

This PR may be shortsighted. Hardcoding this value will likely cause problems during the transition to GovCloud when we need to deploy sites in both regions.

I am suggesting closing this PR and adding `AWS_DEFAULT_REGION` as a variable provided to the container environment by the main web app here: https://github.com/18F/federalist/blob/master/api/services/SQS.js#L38