### PR TITLE
Only set AWS_DEFAULT_REGION if it is not already set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM 18fgsa/docker-ruby-ubuntu
 
+# Defaults for ENV vairables
+ENV AWS_DEFAULT_REGION "us-east-1"
+
 # Preload recent Jekyll versions and install github-pages gem
 RUN gem install jekyll jekyll:3.0.1 jekyll:3.0.0 jekyll:2.5.3 jekyll:2.4.0 github-pages
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Any errors or final status codes are `POST`ed to a URL.
 Configure the build process with following environment variables:
 
 - `AWS_ACCESS_KEY_ID` AWS access key
+- `AWS_DEFAULT_REGION` AWS region
 - `AWS_SECRET_ACCESS_KEY` AWS secret key
 - `CALLBACK` a URL that will receive a `POST` request with a JSON body including the `status` code and output `message` from the Jekyll process
 - `BUCKET` S3 bucket to upload the built site

--- a/publish.sh
+++ b/publish.sh
@@ -16,8 +16,6 @@ for i in `find . | grep -E "\.html$|\.css$|\.js$|\.json$|\.svg$"`; do
   fi
 done
 
-export AWS_DEFAULT_REGION=us-east-1
-
 # sync compressed files
 aws s3 sync . s3://${BUCKET}/${PREFIX}/ --no-follow-symlinks \
   --delete --content-encoding gzip --cache-control $CACHE_CONTROL --exclude "*" \


### PR DESCRIPTION
The `AWS_DEFAULT_REGION` is the variable that describes which region the site will be published to.

Before this commit, the region was hardcoded to "us-east-1". This created problems migrating to GovCloud.

Requiring the AWS region be explicitly set invites its own problems because it requires us to modify the production app running in E/W.

This commit configures the build environment so the AWS region can be overridden, but defaults to "us-east-1". This allows us to support legacy behavior, while being able to provide an override to publish sites to S3 in GovCloud.

closes #19