### PR TITLE
Rename PREFIX to SITE_PREFIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Configure the build process with following environment variables:
 - `CONFIG` A yaml block of configuration to add to `_config.yml` before building
 - `REPOSITORY` Name of the re
 - `OWNER` Owner (GitHub user) of the repository
-- `PREFIX` Prefix for assets on S3
+- `SITE_PREFIX` Prefix for assets on S3
 - `GITHUB_TOKEN` GitHub oauth token for cloning the repository
 - `GENERATOR` The static generator to use to build the site (`jekyll` or `hugo`\*; anything else will just publish all files in the repository)
 - `FEDERALIST_BUILDER_CALLBACK` The callback URL the container should use to let federalist-builder know that it has finished.

--- a/publish.sh
+++ b/publish.sh
@@ -17,12 +17,12 @@ for i in `find . | grep -E "\.html$|\.css$|\.js$|\.json$|\.svg$"`; do
 done
 
 # sync compressed files
-aws s3 sync . s3://${BUCKET}/${PREFIX}/ --no-follow-symlinks \
+aws s3 sync . s3://${BUCKET}/${SITE_PREFIX}/ --no-follow-symlinks \
   --delete --content-encoding gzip --cache-control $CACHE_CONTROL --exclude "*" \
   --include "*.html" --include "*.css" --include "*.js" --include "*.json" --include "*.svg"
 
 # sync remaining files
-aws s3 sync . s3://${BUCKET}/${PREFIX}/ --no-follow-symlinks \
+aws s3 sync . s3://${BUCKET}/${SITE_PREFIX}/ --no-follow-symlinks \
   --delete --cache-control $CACHE_CONTROL \
   --exclude "*.html" --exclude "*.css" --exclude "*.js" --exclude "*.json" --exclude "*.svg"
 
@@ -30,6 +30,6 @@ aws s3 sync . s3://${BUCKET}/${PREFIX}/ --no-follow-symlinks \
 # TODO: this is slow... can it be run in batch or avoid deleting these on sync?
 for i in `find . -type d -print | cut -c 3-`; do
   aws s3api put-object --cache-control $CACHE_CONTROL \
-    --bucket $BUCKET --key ${PREFIX}/$i \
+    --bucket $BUCKET --key ${SITE_PREFIX}/$i \
     --website-redirect-location "${BASEURL}/$i/"
 done


### PR DESCRIPTION
This commit responds to a rename of the variable `PREFIX` to
`SITE_PREFIX` in the container environment. This rename was necessary to
avoid a collision with the `PREFIX` environment variable used by npm.

ref 18F/federalist#584