### PR TITLE
Initialize nvm before using it build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY *.sh /app/
 WORKDIR /src
 
 # Run the build script when container starts
-CMD ["bash", "-l", "/app/main.sh"]
+CMD ["bash", "/app/main.sh"]

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,9 @@ unset FEDERALIST_BUILDER_CALLBACK
 
 # Run build process based on configuration files
 
+# Initialize nvm
+. $NVM_DIR/nvm.sh
+
 # use .nvmrc if it exists
 if [[ -f .nvmrc ]]; then
   nvm install


### PR DESCRIPTION
This commit reverts changes in 280b15961363cbae4dbe3b39f2016e08ccdd96eb
and initializes nvm before using it in the build script.

Even though using bash in login mode makes nvm available in login mode to the
script it is invoked on, it does not make it available to child scripts
that script invokes. Because of this, login mode cannot be used to make
nvm available to build.sh. This change removes login mode and
initializes nvm in build.sh before using it.