### PR TITLE
Add build container logging

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,8 +11,9 @@ shopt -s extglob dotglob
 unset AWS_ACCESS_KEY_ID
 unset AWS_SECRET_ACCESS_KEY
 unset GITHUB_TOKEN
-unset CALLBACK
-unset FEDERALIST_BUILDER_CALLBACK 
+unset STATUS_CALLBACK
+unset LOG_CALLBACK
+unset FEDERALIST_BUILDER_CALLBACK
 
 # Run build process based on configuration files
 


### PR DESCRIPTION
This commit communicates with the web application every time it finishes
running a script. The purpose of this is to provide the web application
with build logs that it can display to the user to be used for more
in-depth debugging when issues happen in the build container.