### PR TITLE
Remove explicit source option from Jekyll build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,9 +24,9 @@ if [ "$GENERATOR" = "jekyll" ]; then
 
   if [[ -f Gemfile ]]; then
     bundle install --quiet
-    bundle exec jekyll build --source . --destination ./_site
+    bundle exec jekyll build --destination ./_site
   else
-    jekyll build --source . --destination ./_site
+    jekyll build --destination ./_site
   fi
 
 # Hugo


### PR DESCRIPTION
This commit removes the explicit source option from the Jekyll config.

The CLI option overrides any option specified in `_config.yml`. This meant sites that have their site's source files in a directory besides the project root could not be built correctly.

Ref 18f/federalist#180