### PR TITLE
Only install production node modules

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ fi
 # install from package.json if it exists
 # run the federalist command
 if [[ -f package.json ]]; then
-  npm install
+  npm install --only=production
   npm run federalist || true
 fi
 


### PR DESCRIPTION
To keep the amount of time `npm install` takes, the amount of disk it
uses, and the amount of native packages it depends on, this commit adds
the `--only=production` flag to `npm install` so that it will only
install packages listed as dependencies.