### PR TITLE
Add python 2.7 to the build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM 18fgsa/docker-ruby-ubuntu
+RUN apt-get update
 
 # Defaults for ENV vairables
 ENV AWS_DEFAULT_REGION "us-east-1"
@@ -9,6 +10,10 @@ RUN gem install jekyll jekyll:3.0.1 jekyll:3.0.0 jekyll:2.5.3 jekyll:2.4.0 githu
 # Install the AWS CLI
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
   && pip install awscli
+
+# node-gyp needs Python 2.7
+RUN apt-get install -y python2.7
+ENV PYTHON /usr/bin/python2.7
 
 # Copy the script files
 COPY *.sh /app/


### PR DESCRIPTION
Node-gyp requires Python 2.7 to build. Lots of older node modules depend
on node-gyp. This commit makes Python 2.7 available in the build
container for those older node modules.