### PR TITLE
Use `--production` instead of `--only=production` on npm install

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ fi
 # install from package.json if it exists
 # run the federalist command
 if [[ -f package.json ]]; then
-  npm install --only=production
+  npm install --production
   npm run federalist || true
 fi
 


### PR DESCRIPTION
The `npm install` option `--only=production` is not supported by npm v4 which is our default node version. This commit switches to `--production` which looks like it is supported by v4, v6, and v7.