### PR TITLE
Remove git details from site config

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,6 @@ fi
 if [ "$GENERATOR" = "jekyll" ]; then
 
   # Add Federalist configuration settings
-  git log -1 --pretty=format:'%ncommit: {%n "commit": "%H",%n "author": "%an <%ae>",%n "date": "%ad",%n "message": "%s"%n}' >> _config.yml
   echo -e "\nbaseurl: ${BASEURL-"''"}\nbranch: ${BRANCH}\n${CONFIG}" >> _config.yml
 
   if [[ -f Gemfile ]]; then


### PR DESCRIPTION
Prior to this commit, details about the commit were added to the site's config before the site was built. This created problems when the commit's message had syntax that resulted in malformed yaml, for example, a `"` character in a commit message. This would create yaml parse errors when the site was building, failing the build.

This commit removes that commit data since it does not seem to be used by any sites, and there doesn't seem to be a straightforward fix for the issue above:

Ref #823