### PR TITLE
Stop scary "missing federalist script" warning

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,7 +30,12 @@ fi
 # run the federalist command
 if [[ -f package.json ]]; then
   npm install --production
-  npm run federalist || true
+
+  # Only run the federalist script if it is present
+  FEDERALIST_SCRIPT=$(node -e "require('./package.json').scripts.federalist ? console.log('federalist') : null")
+  if [[ $FEDERALIST_SCRIPT = "federalist" ]]; then
+    npm run federalist
+  fi;
 fi
 
 # Jekyll with Gemfile plugins


### PR DESCRIPTION
When a build a `pacakge.json` file, the build container would run `npm run federalist || true`. This allowed users to add custom npm scripts, but had a few problems:

- Sites without a `federalist` script would see a disconcerting npm error about a missing federalist script
- Sites with a broken `federalist` script would not see their builds fail

This commit adds a conditional that checks whether the script is present in the `package.json` before attempting to run it. This means that the error will no longer appear for sites w/o a federalist script. In addition, the build will fail if the federalist script has a nonzero exit code.

Ref #33