### PR TITLE
Improve build container logging and remove superfluous activities

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,25 +18,33 @@ unset FEDERALIST_BUILDER_CALLBACK
 # Run build process based on configuration files
 
 # Initialize nvm
+echo "[build.sh] Initializing NVM"
 . $NVM_DIR/nvm.sh
 
 # use .nvmrc if it exists
 if [[ -f .nvmrc ]]; then
+  echo "[build.sh] Using node version specified in .nvmrc"
   nvm install
   nvm use
 fi
+echo "[build.sh] Node version: $(node -v)"
+echo "[build.sh] NPM version: $(npm -v)"
 
 # install from package.json if it exists
 # run the federalist command
 if [[ -f package.json ]]; then
+  echo "[build.sh] Installing dependencies in package.json"
   npm install --production
 
   # Only run the federalist script if it is present
   FEDERALIST_SCRIPT=$(node -e "require('./package.json').scripts.federalist ? console.log('federalist') : null")
   if [[ $FEDERALIST_SCRIPT = "federalist" ]]; then
+    echo "[build.sh] Running federalist build script in package.json"
     npm run federalist
   fi;
 fi
+
+echo "[build.sh] Using build engine: $GENERATOR"
 
 # Jekyll with Gemfile plugins
 if [ "$GENERATOR" = "jekyll" ]; then
@@ -45,9 +53,12 @@ if [ "$GENERATOR" = "jekyll" ]; then
   echo -e "\nbaseurl: ${BASEURL-"''"}\nbranch: ${BRANCH}\n${CONFIG}" >> _config.yml
 
   if [[ -f Gemfile ]]; then
-    bundle install --quiet
+    echo "[build.sh] Installing dependencies in Gemfile"
+    bundle install
+    echo "[build.sh] Building using Jekyll version: $(bundle exec jekyll -v)"
     bundle exec jekyll build --destination ./_site
   else
+    echo "[build.sh] Building using Jekyll version: $(bundle exec jekyll -v)"
     jekyll build --destination ./_site
   fi
 

--- a/clone.sh
+++ b/clone.sh
@@ -6,14 +6,18 @@ set -o pipefail
 
 # Download repository from GitHub
 if [ -n "$SOURCE_OWNER" ] && [ -n "$SOURCE_REPO" ]; then
+  echo "[clone.sh] Cloning a new template site"
   git clone -b $BRANCH --single-branch \
     https://${GITHUB_TOKEN}@github.com/${SOURCE_OWNER}/${SOURCE_REPO}.git .
   git remote add destination https://${GITHUB_TOKEN}@github.com/${OWNER}/${REPOSITORY}.git
+  echo "[clone.sh] Pushing site to $SOURCE_OWNER/$SOURCE_REPO"
   git push destination $BRANCH
 else
+  echo "[clone.sh] Cloning site"
   git clone -b $BRANCH --single-branch \
     https://${GITHUB_TOKEN}@github.com/${OWNER}/${REPOSITORY}.git .
 fi
 
 # Remove _site if it exists (otherwise we'll get a permission error)
+echo "[clone.sh] Cleaning up"
 rm -rf _site

--- a/publish.sh
+++ b/publish.sh
@@ -8,6 +8,7 @@ set -o pipefail
 cd ./_site/
 
 # compress files
+echo "[publish.sh] Compressing files"
 export IFS=$'\n'
 for i in `find . | grep -E "\.html$|\.css$|\.js$|\.json$|\.svg$"`; do
   if [ ! -d "$i" ]; then
@@ -17,22 +18,15 @@ for i in `find . | grep -E "\.html$|\.css$|\.js$|\.json$|\.svg$"`; do
 done
 
 # sync compressed files
+echo "[publish.sh] Uploading compressed files"
 aws s3 sync . s3://${BUCKET}/${SITE_PREFIX}/ --no-follow-symlinks \
   --delete --content-encoding gzip --cache-control $CACHE_CONTROL --exclude "*" \
   --sse "AES256" \
   --include "*.html" --include "*.css" --include "*.js" --include "*.json" --include "*.svg"
 
 # sync remaining files
+echo "[publish.sh] Uploading remaining files"
 aws s3 sync . s3://${BUCKET}/${SITE_PREFIX}/ --no-follow-symlinks \
   --delete --cache-control $CACHE_CONTROL \
   --sse "AES256" \
   --exclude "*.html" --exclude "*.css" --exclude "*.js" --exclude "*.json" --exclude "*.svg"
-
-# create redirects for directories
-# TODO: this is slow... can it be run in batch or avoid deleting these on sync?
-for i in `find . -type d -print | cut -c 3-`; do
-  aws s3api put-object --cache-control $CACHE_CONTROL \
-    --bucket $BUCKET --key ${SITE_PREFIX}/$i \
-    --server-side-encryption "AES256" \
-    --website-redirect-location "${BASEURL}/$i/"
-done


### PR DESCRIPTION
This commit is the result of work to debug an issue that was noticed on staging where federalist-builder was reporting that all builds were timing out for some larger sites. The issue was very hard to discover due to the lack of visibility into the container's activities.

This commit adds additional visibility, and removes several superfluous activities that were discovered to be the cause of the mysterious build timeouts. The changes are:

- Use `tee` to follow logs from build scripts in real time in container logs
- Add logging statements to make it clear where in the process the build is
- Use a base64 encoded string for the output in the build logs callback to avoid weird javascript string parsing errors
- Limit the length of build log output when calling back to the log callback to keep excessively long logs from exceeding bash argument length
- Preserve newlines in callbacks back to Federalist
- Remove redirect creation in `publish.sh` since it is long-running and unnecessary in an S3 bucket with a propper website configuration