### PR TITLE
Allow sites to use RVM to swtich ruby versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
 FROM 18fgsa/docker-ruby-ubuntu
 RUN apt-get update
 
+# Create a federalist urser
+RUN useradd -G rvm federalist
+RUN mkdir /home/federalist
+RUN chown -R federalist /home/federalist
+
 # Defaults for ENV vairables
 ENV AWS_DEFAULT_REGION "us-east-1"
 
-# Preload recent Jekyll versions and install github-pages gem
-RUN gem install jekyll jekyll:3.0.1 jekyll:3.0.0 jekyll:2.5.3 jekyll:2.4.0 github-pages
+# skip installing gem documentation
+RUN echo 'install: --no-document\nupdate: --no-document' >> "/home/federalist/.gemrc"
 
 # Install the AWS CLI
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
@@ -17,8 +22,14 @@ ENV PYTHON /usr/bin/python2.7
 
 # Copy the script files
 COPY *.sh /app/
+RUN chmod -R 555 /app
 
+# Add the working directory
 WORKDIR /src
+RUN chown -R federalist /src
+
+# Change to the Federalist user
+USER federalist
 
 # Run the build script when container starts
 CMD ["bash", "/app/main.sh"]

--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,18 @@ unset FEDERALIST_BUILDER_CALLBACK
 
 # Run build process based on configuration files
 
+# Init RMV
+echo "[build.sh] Initializing RVM"
+source /usr/local/rvm/scripts/rvm
+
+# Install new ruby version if .ruby-version is present
+echo $PATH
+if [[ -f .ruby-version ]]; then
+  echo "[build.sh] Using ruby version in .ruby-version"
+  rvm install "$(cat .ruby-version)"
+fi
+echo "[build.sh] Ruby version: $(ruby -v)"
+
 # Initialize nvm
 echo "[build.sh] Initializing NVM"
 . $NVM_DIR/nvm.sh
@@ -53,12 +65,16 @@ if [ "$GENERATOR" = "jekyll" ]; then
   echo -e "\nbaseurl: ${BASEURL-"''"}\nbranch: ${BRANCH}\n${CONFIG}" >> _config.yml
 
   if [[ -f Gemfile ]]; then
+    echo "[build.sh] Setting up bundler"
+    gem install bundler
     echo "[build.sh] Installing dependencies in Gemfile"
     bundle install
     echo "[build.sh] Building using Jekyll version: $(bundle exec jekyll -v)"
     bundle exec jekyll build --destination ./_site
   else
-    echo "[build.sh] Building using Jekyll version: $(bundle exec jekyll -v)"
+    echo "[build.sh] Installing Jekyll"
+    gem install jekyll
+    echo "[build.sh] Building using Jekyll version: $(jekyll -v)"
     jekyll build --destination ./_site
   fi
 


### PR DESCRIPTION
This commit adds the ability for sites to set their ruby version using a `.ruby-version` file.

This commit adds a Federalist user to build the sites since running RVM as root can be kind of shaky. It also moves more of the configuration for the ruby install into build.sh. This is necessary because switching ruby versions means the old configurations will be left behind with the old version.

Ref #6