### PR TITLE
Unset pipefail before using pipes that can fail

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -4,6 +4,7 @@
 
 # Stop script on errors
 set -e
+set -o pipefail
 
 # Create a build log
 log_output () {
@@ -13,14 +14,15 @@ log_output () {
     REQUEST="{\"source\":\"`echo $1`\",\"output\":\"`echo -n "$2" | base64 --wrap=0`\"}"
   fi
 
+  set +o pipefail
   curl -H "Content-Type: application/json" \
     -d $REQUEST \
     $LOG_CALLBACK || true
+  set -o pipefail
 }
 
 # Post to webhook on completion
 post () {
-
   # Capture exit status
   status=$?
 
@@ -33,6 +35,7 @@ post () {
   fi
 
   # POST to federalist's build finished endpoint && POST to federalist-builder's build finished endpoint
+  set +o pipefail
   curl -H "Content-Type: application/json" \
     -d "{\"status\":\"$status\",\"message\":\"`echo -n "$output" | base64 --wrap=0`\"}" \
     $STATUS_CALLBACK \


### PR DESCRIPTION
We have several points where we do something like this:

```shell
curl some.url.gov ; curl some.other.url.gov || true
```

The purpose of this is to not break the build if any external services are down. This is very useful when reporting build logs, since the request is sent in the middle of the build process.

Additionally, we have build steps where we use `tee` to output the build output into the logs. That looks like this:

```shell
/app/build.sh 2>&1 | tee /dev/stderr
```

When `/app/build.sh` fails there, we want the entire build to fail.

The result of the above is that we want want the container to have `pipefail` enable some of the time, and disabled other times. This commit sets it when the build starts, and momentarily disables it when we do not want it.