### PR TITLE
Fix issue where timed out builds reported success.

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -27,8 +27,12 @@ post () {
   status=$?
 
   # Reset output if no errors
-  if [ $status -eq 0 ]; then
+  if [ $status -eq 0 ] && [ "$build_complete" = "true" ]; then
     output=""
+  elif [ $status -eq 0 ]; then
+    output="The build did not complete. It may have timed out."
+    status=1
+    log_output "ERROR" "$output"
   else
     echo "$output"
     log_output "ERROR" "$output"
@@ -57,5 +61,7 @@ log_output "build.sh" "$output"
 
 output="$($(dirname $0)/publish.sh 2>&1 | tee /dev/stderr)"
 log_output "publish.sh" "$output"
+
+build_complete=true
 
 echo "[main.sh] Done!"


### PR DESCRIPTION
This commit fixes an issue that arose with builds that timed out. When builds would time out, cloud.gov would stop the build would would trigger a call to the `post`. Since the exit code was zero, this would report to Federalist that the build completed successfully, even though it timed out.

This commit changes the `main.sh` script to detect when a build does not complete before exiting, and reports an error in that case, with an error message hinting that the build may have timed out.