### PR TITLE
Don't publish git directory

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -7,6 +7,9 @@ set -o pipefail
 # Work in site directory
 cd ./_site/
 
+# Remove the .git directory
+rm -rf .*
+
 # compress files
 echo "[publish.sh] Compressing files"
 export IFS=$'\n'


### PR DESCRIPTION
After build, site's may contain a `.git` directory which we don't want to appear on the public internet. This commit removes that directory before publishing.

cc: @commit-dkp