### PR TITLE
Fix dotfile regex

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -8,7 +8,7 @@ set -o pipefail
 cd ./_site/
 
 # Remove the .git directory
-rm -rf .*
+rm -rf .[^.] .??*
 
 # compress files
 echo "[publish.sh] Compressing files"


### PR DESCRIPTION
The regex we were using to match dotfiles didn't work because it matched `.` and `..`. This commit users a more sophisticated regex to look for dotfiles.

cc @commit-dkp