### PR TITLE
Add note about branches to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**NOTE**: The master branch for this repo is the default branch so Docker Hub will build this image correctly for our legacy environment. Our legacy environment is being spun down. People should not use `master` and should instead prefer the `staging` branch which has the latest changes and security patches.
+
 # Docker Builder for federalist
 
 This is a Docker image that runs Jekyll to build a and uploads it to AWS S3. It's used to allow Jekyll sites to build with user-provided plugins in a safe space.


### PR DESCRIPTION
This commit adds a note the README explaining that the default branch does not have up to date fixes or vulnerability mitigations.