### PR TITLE
Timeout builds after they run for 20 minutes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ COPY *.sh /app/
 WORKDIR /src
 
 # Run the build script when container starts
-CMD ["bash", "-l", "/app/main.sh"]
+CMD ["bash", "/app/run.sh"]

--- a/main.sh
+++ b/main.sh
@@ -38,15 +38,16 @@ post () {
     log_output "ERROR" "$output"
   fi
 
-  # POST to federalist's build finished endpoint && POST to federalist-builder's build finished endpoint
+  set +e
   set +o pipefail
+
+  # Post to the Federalist web application endpoint with status and output
   curl -H "Content-Type: application/json" \
     -d "{\"status\":\"$status\",\"message\":\"`echo -n "$output" | base64 --wrap=0`\"}" \
-    $STATUS_CALLBACK \
-    ; curl -X "DELETE" $FEDERALIST_BUILDER_CALLBACK || true
+    $STATUS_CALLBACK || true
 
-  # Sleep until restarted for the next build
-  sleep infinity
+  # Post the Federalist build scheduler to alert that the container is available
+  curl -X "DELETE" $FEDERALIST_BUILDER_CALLBACK || true
 }
 
 # Post before exit

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,2 @@
+timeout $((20 * 60)) /bin/bash -l /app/main.sh
+sleep infinity


### PR DESCRIPTION
This commit adds a new script named `run.sh` which invokes `main.sh`
with an instruction to time it out after 20 minutes. This means that if
the process building the site takes longer than 20 minutes to execute,
this new script will stop it.

After setting the timeout, the run script then sleeps, and invocation
that was removed from the main script.

The introduction of a new script was necessary because `timeout` cannot
be used to run a function. Complex commands must be contained inside a
separate script and run that way.