### PR TITLE
Add baseurl to root redirect destination

### DIFF
--- a/publish.rb
+++ b/publish.rb
@@ -116,7 +116,7 @@ class SiteRedirect < SiteObject
 
   def destination
     if filename == ""
-      "/"
+      "#{BASEURL}/"
     else
       "#{BASEURL}/#{filename}/"
     end


### PR DESCRIPTION
The root URL's redirect was not prefixed by the root url, breaking the sites built without a custom domain. This commit adds the baseurl prefix to the redirect for the root url.

Ref #53